### PR TITLE
add uv unsupported not to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
         patterns:
           - '*'
 
+  # Unfortunately does not yet support uv lockfiles
+  # https://github.com/dependabot/dependabot-core/issues/10478
   - package-ecosystem: "pip"
     directory: "/"
     schedule:

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: '>=2.18.3'
+requires_ansible: '>=2.16.0'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,16 +22,16 @@ classifiers = [
     "Topic :: System",
     "Topic :: System :: Networking",
 ]
-requires-python = ">=3.13"
+requires-python = "~=3.13"
 dependencies = [
-    "ansible>=11.3.0",
+    "ansible~=9.12.0",
 ]
 
 [dependency-groups]
 dev = [
-    "ansible-lint>=25.1.3",
-    "molecule>=25.3.1",
-    "molecule-plugins[docker]>=23.7.0",
+    "ansible-lint~=25.1.3",
+    "molecule~=25.3.1",
+    "molecule-plugins[docker]~=23.7.0",
     "pre-commit>=4.1.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 1
-requires-python = ">=3.13"
+requires-python = ">=3.13, <4"
 resolution-markers = [
     "sys_platform == 'linux2'",
     "sys_platform == 'linux'",
@@ -9,14 +9,14 @@ resolution-markers = [
 
 [[package]]
 name = "ansible"
-version = "11.3.0"
+version = "9.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ansible-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f3/0d/33a32c7e119c594d87d599afdf787ba50262042b8daaeaa32036b3fc446d/ansible-11.3.0.tar.gz", hash = "sha256:90b409f630dc6d558224409a3948314ede1bcda6db2d03c17708cef6117a6103", size = 42493561 }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/fb/4a53d3cc1b3d6cffc9d62ac968815897e6d8f28db242123d15e469de9870/ansible-9.12.0.tar.gz", hash = "sha256:54557393fae5768ee6430491c55b74f7831d89dd198d3d74431edaae44004298", size = 40954094 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/bc/d91554f4490314ebea31b375ffdbe5ef130211ac0486d41b940dae95bcc7/ansible-11.3.0-py3-none-any.whl", hash = "sha256:699c76dd00e841e7307d4829b0454c3ee746df8e4488fa10825014a01d42efcc", size = 54163606 },
+    { url = "https://files.pythonhosted.org/packages/dc/96/830575b7e33d3f4f98530a5bea11f2534e7389a03a8723cbd7cbbbca6d50/ansible-9.12.0-py3-none-any.whl", hash = "sha256:fdd5738ae5b6ddb7c8bc8e7117df0b7c4e0b261fdb60b66e073843379a863b59", size = 49401561 },
 ]
 
 [[package]]
@@ -37,7 +37,7 @@ wheels = [
 
 [[package]]
 name = "ansible-core"
-version = "2.18.3"
+version = "2.16.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
@@ -46,9 +46,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "resolvelib" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/39/26/409259cf95b0ef3471f45837cfda01ae87bcced66dfef7691715184550cf/ansible_core-2.18.3.tar.gz", hash = "sha256:8c4eaca40845238e2601b9bc9dbfbd4f6ed3502cb8b2632789f75ce478abfdee", size = 3077314 }
+sdist = { url = "https://files.pythonhosted.org/packages/de/5c/ac61c1444b36b07bfde70dea95beb5a89525b11c92f6e7ef8b87e3ba0248/ansible_core-2.16.14.tar.gz", hash = "sha256:80279fffd98686badfaa32e1ec785d98a6df1b2fc1e4097dec0597640d746415", size = 3159494 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/df/8f1d7ec589ceba8c34ebdf7abc083b99ab8c9112bda5f3bfb88b223f75bb/ansible_core-2.18.3-py3-none-any.whl", hash = "sha256:4d5120916b6d36881185c0c7231cdb7b1675f7dddd1a7a833a7d67d56bcdfcc8", size = 2216727 },
+    { url = "https://files.pythonhosted.org/packages/ce/c3/ad44b1a08f3dbf591dc1ab58619446a6d473fabf3361e553e3e75ed97cc8/ansible_core-2.16.14-py3-none-any.whl", hash = "sha256:b7b6df2fb0cf065b091d0332e98afbe4b028f2ffe58078e7dcf83f09e35cc8ad", size = 2254208 },
 ]
 
 [[package]]
@@ -93,13 +93,13 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "ansible", specifier = ">=11.3.0" }]
+requires-dist = [{ name = "ansible", specifier = "~=9.12.0" }]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "ansible-lint", specifier = ">=25.1.3" },
-    { name = "molecule", specifier = ">=25.3.1" },
-    { name = "molecule-plugins", extras = ["docker"], specifier = ">=23.7.0" },
+    { name = "ansible-lint", specifier = "~=25.1.3" },
+    { name = "molecule", specifier = "~=25.3.1" },
+    { name = "molecule-plugins", extras = ["docker"], specifier = "~=23.7.0" },
     { name = "pre-commit", specifier = ">=4.1.0" },
 ]
 


### PR DESCRIPTION
When porting from https://github.com/artis3n/ansible-role-tailscale , I installed that latest Ansible which recently became 11.x. The prior repo was on 9.x (https://github.com/artis3n/ansible-role-tailscale/issues/481).

Reverting ansible version in dev dependencies for the CI suite to match the prior repo.