### PR TITLE
Handle new dnf addrepo syntax in Fedora 41 and onwards

### DIFF
--- a/.github/workflows/pull_request_target.yml
+++ b/.github/workflows/pull_request_target.yml
@@ -37,9 +37,10 @@ jobs:
           - image: geerlingguy/docker-debian12-ansible:latest
           - image: geerlingguy/docker-debian11-ansible:latest
             command: /lib/systemd/systemd
-          - image: geerlingguy/docker-fedora39-ansible:latest
+          - image: geerlingguy/docker-fedora40-ansible:latest
+          - image: geerlingguy/docker-fedora41-ansible:latest
           - image: ghcr.io/artis3n/docker-arch-ansible:latest
-          - image: ghcr.io/artis3n/docker-opensuse-tumbleweed-ansible:latest
+          # - image: ghcr.io/artis3n/docker-opensuse-tumbleweed-ansible:latest
           # - image: ghcr.io/artis3n/docker-opensuse-leap-ansible:latest
           #   command: /lib/systemd/systemd
 

--- a/roles/device/tasks/fedora/install.yml
+++ b/roles/device/tasks/fedora/install.yml
@@ -15,19 +15,24 @@
     name: "{{ tailscale_dnf_dependencies }}"
     state: present
 
-- name: Fedora (Version <=40) | Add DNF Repo
+- name: Fedora | Add DNF Repo (Legacy)
   become: true
   ansible.builtin.command: dnf config-manager --add-repo {{ tailscale_dnf_repos[ansible_distribution] }}
   args:
     creates: /etc/yum.repos.d/tailscale.repo
-  when: ansible_facts['distribution_version'] | int <= 40
+  when: >
+    (ansible_distribution == 'Fedora' and ansible_facts['distribution_version'] | int <= 40)
+    or ansible_distribution == 'Amazon'
 
-- name: Fedora (Version >= 41) | Add DNF Repo
+- name: Fedora | Add DNF Repo
   become: true
   ansible.builtin.command: dnf config-manager addrepo --from-repofile={{ tailscale_dnf_repos[ansible_distribution] }}
   args:
     creates: /etc/yum.repos.d/tailscale.repo
-  when: (ansible_distribution == 'Fedora') and (ansible_distribution_major_version | int >= 41)
+  when:
+    # Amazon Linux 2023 also uses the Fedora install steps
+    - ansible_distribution == 'Fedora'
+    - ansible_facts['distribution_version'] | int >= 41
 
 - name: Fedora | Install Tailscale
   become: true

--- a/roles/device/tasks/fedora/install.yml
+++ b/roles/device/tasks/fedora/install.yml
@@ -15,11 +15,19 @@
     name: "{{ tailscale_dnf_dependencies }}"
     state: present
 
-- name: Fedora | Add DNF Repo
+- name: Fedora (Version <=40) | Add DNF Repo
   become: true
   ansible.builtin.command: dnf config-manager --add-repo {{ tailscale_dnf_repos[ansible_distribution] }}
   args:
     creates: /etc/yum.repos.d/tailscale.repo
+  when: ansible_facts['distribution_version'] | int <= 40
+
+- name: Fedora (Version >= 41) | Add DNF Repo
+  become: true
+  ansible.builtin.command: dnf config-manager addrepo --from-repofile={{ tailscale_dnf_repos[ansible_distribution] }}
+  args:
+    creates: /etc/yum.repos.d/tailscale.repo
+  when: ansible_facts['distribution_version'] | int >= 41
 
 - name: Fedora | Install Tailscale
   become: true

--- a/roles/device/tasks/fedora/install.yml
+++ b/roles/device/tasks/fedora/install.yml
@@ -27,7 +27,7 @@
   ansible.builtin.command: dnf config-manager addrepo --from-repofile={{ tailscale_dnf_repos[ansible_distribution] }}
   args:
     creates: /etc/yum.repos.d/tailscale.repo
-  when: ansible_facts['distribution_version'] | int >= 41
+  when: (ansible_distribution == 'Fedora') and (ansible_distribution_major_version | int >= 41)
 
 - name: Fedora | Install Tailscale
   become: true


### PR DESCRIPTION
Fedora changed the syntax for adding repos to dnf with dnf 5. See here for more Information: https://docs.fedoraproject.org/en-US/quick-docs/adding-or-removing-software-repositories-in-fedora/

Without this patch, isntallign Tailscale fails on Fedora 41.
I tested it locally on my servers and it worked. Please let me know if there is anything blocking this Pull request