### PR TITLE
Modernization of Debian installation steps

### DIFF
--- a/roles/machine/tasks/debian/install.yml
+++ b/roles/machine/tasks/debian/install.yml
@@ -10,34 +10,33 @@
     cache_valid_time: 3600
     state: present
 
-- name: Debian | Legacy Apt Dependencies
+- name: Debian | Add Tailscale Repository
   become: true
-  ansible.builtin.apt:
-    name: "{{ tailscale_legacy_apt_dependencies }}"
-  when:
-    - ansible_distribution_major_version | int < 11
-    # Prelease versions of debian tend to not have a version integer yet
-    - ansible_distribution_major_version != "testing"
-    - ansible_distribution_major_version != "n/a"
+  ansible.builtin.deb822_repository:
+    name: tailscale
+    types: deb
+    uris: https://pkgs.tailscale.com/{{ release_stability | lower }}/{{ tailscale_debian_distro[ansible_distribution | lower] }}
+    suites: "{{ ansible_distribution_release }}"
+    components: main
+    signed_by: "{{ tailscale_apt_signkey }}"
+    state: present
 
-- name: Debian | Add Tailscale Signing Key
-  become: true
-  ansible.builtin.get_url:
-    url: "{{ tailscale_apt_signkey }}"
-    dest: "{{ tailscale_apt_keyring_path }}"
-    mode: '0644'
-
-- name: Debian | Add Tailscale Deb
+- name: Debian | Remove Legacy Tailscale Deb
   become: true
   ansible.builtin.apt_repository:
     repo: "{{ tailscale_apt_deb }}"
-    filename: "tailscale"
-    state: present
+    state: absent
     codename: "{{ apt_codename }}"
+
+- name: Debian | Remove Tailscale Signing Key from legacy keyrings path
+  become: true
+  ansible.builtin.file:
+    path: "{{ tailscale_apt_keyring_path }}"
+    state: absent
 
 - name: Debian | Install Tailscale
   become: true
   ansible.builtin.apt:
     name: "{{ tailscale_package }}"
-    cache_valid_time: 3600
-    state: '{{ state }}'
+    update_cache: true
+    state: "{{ state }}"

--- a/roles/machine/tasks/debian/uninstall.yml
+++ b/roles/machine/tasks/debian/uninstall.yml
@@ -16,12 +16,23 @@
     name: "{{ tailscale_package }}"
     state: absent
 
-- name: Debian | Remove Tailscale Deb
+- name: Debian | Remove Legacy Tailscale Deb
   become: true
   ansible.builtin.apt_repository:
     repo: "{{ tailscale_apt_deb }}"
     state: absent
     codename: "{{ apt_codename }}"
+
+- name: Debian | Remove Tailscale Repository
+  become: true
+  ansible.builtin.deb822_repository:
+    name: tailscale
+    types: deb
+    uris: https://pkgs.tailscale.com/{{ release_stability | lower }}/{{ tailscale_debian_distro[ansible_distribution | lower] }}
+    suites: "{{ ansible_distribution_release }}"
+    components: main
+    signed_by: "{{ tailscale_apt_signkey }}"
+    state: absent
 
 - name: Debian | Remove Tailscale Signing Key from trusted.gpg
   become: true
@@ -29,8 +40,14 @@
     url: "{{ tailscale_apt_signkey }}"
     state: absent
 
-- name: Debian | Remove Tailscale Signing Key from keyrings
+- name: Debian | Remove Tailscale Signing Key from legacy keyrings path
   become: true
   ansible.builtin.file:
     path: "{{ tailscale_apt_keyring_path }}"
+    state: absent
+
+- name: Debian | Remove Tailscale Keyring
+  become: true
+  ansible.builtin.file:
+    path: /etc/apt/keyrings/tailscale.gpg
     state: absent

--- a/roles/machine/vars/main.yml
+++ b/roles/machine/vars/main.yml
@@ -28,10 +28,6 @@ tailscale_apt_dependencies:
   - apt-transport-https
   - python3-apt
 
-tailscale_legacy_apt_dependencies:
-  # Only install on legacy Debian systems
-  - python-apt
-
 tailscale_debian_distro:
   pop!_os: ubuntu
   ubuntu: ubuntu


### PR DESCRIPTION
This pull request updates the installation and uninstallation processes for Tailscale on Debian systems, transitioning from legacy methods to the modern `deb822_repository` module for repository management. It also removes legacy dependencies and keyring files, ensuring compatibility with newer Debian versions.

### Changes to Installation Process:

* Updated the Tailscale repository setup to use `ansible.builtin.deb822_repository`, replacing legacy methods.
* Removed Tailscale signing key and keyrings from legacy locations during installation.

### Changes to Uninstallation Process:

* Added steps to remove the Tailscale repository using `deb822_repository` during uninstallation.
* Removed legacy Tailscale keyrings and signing keys from both legacy locations and the new location: `/etc/apt/keyrings/tailscale.gpg`.

### Variable Cleanup:

* Eliminated the `Legacy Apt Dependencies` step, as Python 2 is no longer supported by any current ansible-core release.