### PR TITLE
Allow to skip the tailscale binaries manage

### DIFF
--- a/roles/machine/defaults/main.yml
+++ b/roles/machine/defaults/main.yml
@@ -3,6 +3,8 @@
 
 # Whether to install or uninstall Tailscale. Either 'latest', 'present', or 'absent'
 state: latest
+# Whether to skip the tailscale binaries installation and uninstallation
+tailscale_manage_binaries_skip: false
 # Required Node auth key to authenticate to Tailscale
 tailscale_authkey: ""
 # Optional command-line arguments for 'tailscale up'

--- a/roles/machine/tasks/install.yml
+++ b/roles/machine/tasks/install.yml
@@ -1,26 +1,29 @@
 ---
-- name: Install | CentOS and related families
-  when: >
-    ansible_distribution in tailscale_centos_family_distros
-  ansible.builtin.include_tasks: centos/install.yml
+- name: Install | Tailscale binaries
+  when: "not tailscale_manage_binaries_skip"
+  block:
+    - name: Install | CentOS and related families
+      when: >
+        ansible_distribution in tailscale_centos_family_distros
+      ansible.builtin.include_tasks: centos/install.yml
 
-- name: Install | Debian and related families
-  when: ansible_distribution in tailscale_debian_family_distros
-  ansible.builtin.include_tasks: debian/install.yml
+    - name: Install | Debian and related families
+      when: ansible_distribution in tailscale_debian_family_distros
+      ansible.builtin.include_tasks: debian/install.yml
 
-- name: Install | Fedora and related families
-  when: >
-    ansible_distribution == 'Fedora'
-    or (ansible_distribution == 'Amazon' and ansible_distribution_major_version | int >= 2023)
-  ansible.builtin.include_tasks: fedora/install.yml
+    - name: Install | Fedora and related families
+      when: >
+        ansible_distribution == 'Fedora'
+        or (ansible_distribution == 'Amazon' and ansible_distribution_major_version | int >= 2023)
+      ansible.builtin.include_tasks: fedora/install.yml
 
-- name: Install | Arch
-  when: ansible_distribution == 'Archlinux'
-  ansible.builtin.include_tasks: arch/install.yml
+    - name: Install | Arch
+      when: ansible_distribution == 'Archlinux'
+      ansible.builtin.include_tasks: arch/install.yml
 
-- name: Install | OpenSUSE
-  when: ansible_distribution in tailscale_opensuse_family_distros
-  ansible.builtin.include_tasks: opensuse/install.yml
+    - name: Install | OpenSUSE
+      when: ansible_distribution in tailscale_opensuse_family_distros
+      ansible.builtin.include_tasks: opensuse/install.yml
 
 - name: Install | Remove legacy state folder
   ansible.builtin.file:

--- a/roles/machine/tasks/main.yml
+++ b/roles/machine/tasks/main.yml
@@ -45,6 +45,11 @@
     - state != "absent"
     - not tailscale_up_skip
 
+- name: Skipping manage binaries
+  ansible.builtin.debug:
+    msg: You have set 'tailscale_manage_binaries_skip', so no tailscale binaries will be installed or uninstalled on this node.
+  when: tailscale_manage_binaries_skip
+
 - name: Skipping Authentication
   ansible.builtin.debug:
     msg: You have set 'tailscale_up_skip', so this node will not authenticate to your Tailscale network.

--- a/roles/machine/tasks/uninstall.yml
+++ b/roles/machine/tasks/uninstall.yml
@@ -33,30 +33,33 @@
     enabled: false
   when: tailscale_service in ansible_facts.services
 
-- name: Uninstall | CentOS and related families
-  when: ansible_distribution in tailscale_centos_family_distros
-  ansible.builtin.include_tasks: centos/uninstall.yml
+- name: Uninstall | Tailscale binaries
+  when: "not tailscale_manage_binaries_skip"
+  block:
+    - name: Uninstall | CentOS and related families
+      when: ansible_distribution in tailscale_centos_family_distros
+      ansible.builtin.include_tasks: centos/uninstall.yml
 
-- name: Uninstall | Debian and related families
-  when: ansible_distribution in tailscale_debian_family_distros
-  ansible.builtin.include_tasks: debian/uninstall.yml
+    - name: Uninstall | Debian and related families
+      when: ansible_distribution in tailscale_debian_family_distros
+      ansible.builtin.include_tasks: debian/uninstall.yml
 
-- name: Uninstall | Fedora and related families
-  when: >
-    ansible_distribution == 'Fedora'
-    or (ansible_distribution == 'Amazon' and ansible_distribution_major_version | int >= 2023)
-  ansible.builtin.include_tasks: fedora/uninstall.yml
+    - name: Uninstall | Fedora and related families
+      when: >
+        ansible_distribution == 'Fedora'
+        or (ansible_distribution == 'Amazon' and ansible_distribution_major_version | int >= 2023)
+      ansible.builtin.include_tasks: fedora/uninstall.yml
 
-- name: Uninstall | Arch
-  when: ansible_distribution == 'Archlinux'
-  ansible.builtin.include_tasks: arch/uninstall.yml
+    - name: Uninstall | Arch
+      when: ansible_distribution == 'Archlinux'
+      ansible.builtin.include_tasks: arch/uninstall.yml
 
-- name: Uninstall | OpenSUSE
-  when: ansible_distribution in tailscale_opensuse_family_distros
-  ansible.builtin.include_tasks: opensuse/uninstall.yml
+    - name: Uninstall | OpenSUSE
+      when: ansible_distribution in tailscale_opensuse_family_distros
+      ansible.builtin.include_tasks: opensuse/uninstall.yml
 
-- name: Uninstall | Remove Tailscale Daemon State and Logs
-  become: true
-  ansible.builtin.file:
-    path: "/var/lib/tailscale"
-    state: absent
+    - name: Uninstall | Remove Tailscale Daemon State and Logs
+      become: true
+      ansible.builtin.file:
+        path: "/var/lib/tailscale"
+        state: absent


### PR DESCRIPTION
Hi @artis3n,
I tried to develop a proposal to deal with the feature request #39.
The aim of the pull request is to provide a method to skip the installation of the Tailscale binaries for immutable systems.

It introduces the variable `tailscale_manage_binaries_skip`. Setting it to `true` makes the role skip the installation and uninstallation of the Tailscale system package.

I'm not completely convinced about the variable name, but it's the most suitable one I could think of.