### PR TITLE
Load vars from ansible_facts namespace (future deprecation fix)

### DIFF
--- a/roles/machine/tasks/centos/install.yml
+++ b/roles/machine/tasks/centos/install.yml
@@ -28,7 +28,7 @@
 - name: CentOS | Add Tailscale Repo
   become: true
   when: not tailscale_repo_state.stat.exists
-  ansible.builtin.command: dnf config-manager --add-repo {{ tailscale_yum_repos[ansible_distribution] }}
+  ansible.builtin.command: dnf config-manager --add-repo {{ tailscale_yum_repos[ansible_facts.distribution] }}
   args:
     creates: /etc/yum.repos.d/tailscale.repo
   register: add_tailscale_repo

--- a/roles/machine/tasks/debian/apt-codename.yml
+++ b/roles/machine/tasks/debian/apt-codename.yml
@@ -13,7 +13,7 @@
 - name: Debian | Retrieve Apt ID_LIKE
   check_mode: false
   ansible.builtin.command: >-
-    awk -F= '/^ID_LIKE/ {print $2}' {{ ansible_distribution_file_path }}
+    awk -F= '/^ID_LIKE/ {print $2}' {{ ansible_facts.distribution_file_path }}
   register: apt_id_like
   changed_when: false
 
@@ -23,11 +23,11 @@
 - name: Debian | Retrieve ubuntu_codename on Ubuntu derivatives
   check_mode: false
   ansible.builtin.command: >-
-    awk -F= '/^UBUNTU_CODENAME/ {print $2}' {{ ansible_distribution_file_path }}
+    awk -F= '/^UBUNTU_CODENAME/ {print $2}' {{ ansible_facts.distribution_file_path }}
   register: ubuntu_codename
   when: apt_id_like.stdout == '"ubuntu debian"'
   changed_when: false
 
 - name: Debian | Set codename for apt
   ansible.builtin.set_fact:
-    apt_codename: "{{ ubuntu_codename.stdout | default(ansible_distribution_release) }}"
+    apt_codename: "{{ ubuntu_codename.stdout | default(ansible_facts.distribution_release) }}"

--- a/roles/machine/tasks/debian/install.yml
+++ b/roles/machine/tasks/debian/install.yml
@@ -15,8 +15,8 @@
   ansible.builtin.deb822_repository:
     name: tailscale
     types: deb
-    uris: https://pkgs.tailscale.com/{{ release_stability | lower }}/{{ tailscale_debian_distro[ansible_distribution | lower] }}
-    suites: "{{ ansible_distribution_release }}"
+    uris: https://pkgs.tailscale.com/{{ release_stability | lower }}/{{ tailscale_debian_distro[ansible_facts.distribution | lower] }}
+    suites: "{{ ansible_facts.distribution_release }}"
     components: main
     signed_by: "{{ tailscale_apt_signkey }}"
     state: present

--- a/roles/machine/tasks/debian/uninstall.yml
+++ b/roles/machine/tasks/debian/uninstall.yml
@@ -28,8 +28,8 @@
   ansible.builtin.deb822_repository:
     name: tailscale
     types: deb
-    uris: https://pkgs.tailscale.com/{{ release_stability | lower }}/{{ tailscale_debian_distro[ansible_distribution | lower] }}
-    suites: "{{ ansible_distribution_release }}"
+    uris: https://pkgs.tailscale.com/{{ release_stability | lower }}/{{ tailscale_debian_distro[ansible_facts.distribution | lower] }}
+    suites: "{{ ansible_facts.distribution_release }}"
     components: main
     signed_by: "{{ tailscale_apt_signkey }}"
     state: absent

--- a/roles/machine/tasks/fedora/install.yml
+++ b/roles/machine/tasks/fedora/install.yml
@@ -17,21 +17,21 @@
 
 - name: Fedora | Add DNF Repo (Legacy)
   become: true
-  ansible.builtin.command: dnf config-manager --add-repo {{ tailscale_dnf_repos[ansible_distribution] }}
+  ansible.builtin.command: dnf config-manager --add-repo {{ tailscale_dnf_repos[ansible_facts.distribution] }}
   args:
     creates: /etc/yum.repos.d/tailscale.repo
   when: >
-    (ansible_distribution == 'Fedora' and ansible_facts['distribution_version'] | int <= 40)
-    or ansible_distribution == 'Amazon'
+    (ansible_facts.distribution == 'Fedora' and ansible_facts['distribution_version'] | int <= 40)
+    or ansible_facts.distribution == 'Amazon'
 
 - name: Fedora | Add DNF Repo
   become: true
-  ansible.builtin.command: dnf config-manager addrepo --from-repofile={{ tailscale_dnf_repos[ansible_distribution] }}
+  ansible.builtin.command: dnf config-manager addrepo --from-repofile={{ tailscale_dnf_repos[ansible_facts.distribution] }}
   args:
     creates: /etc/yum.repos.d/tailscale.repo
   when:
     # Amazon Linux 2023 also uses the Fedora install steps
-    - ansible_distribution == 'Fedora'
+    - ansible_facts.distribution == 'Fedora'
     - ansible_facts['distribution_version'] | int >= 41
 
 - name: Fedora | Install Tailscale

--- a/roles/machine/tasks/install.yml
+++ b/roles/machine/tasks/install.yml
@@ -4,25 +4,25 @@
   block:
     - name: Install | CentOS and related families
       when: >
-        ansible_distribution in tailscale_centos_family_distros
+        ansible_facts.distribution in tailscale_centos_family_distros
       ansible.builtin.include_tasks: centos/install.yml
 
     - name: Install | Debian and related families
-      when: ansible_distribution in tailscale_debian_family_distros
+      when: ansible_facts.distribution in tailscale_debian_family_distros
       ansible.builtin.include_tasks: debian/install.yml
 
     - name: Install | Fedora and related families
       when: >
-        ansible_distribution == 'Fedora'
-        or (ansible_distribution == 'Amazon' and ansible_distribution_major_version | int >= 2023)
+        ansible_facts.distribution == 'Fedora'
+        or (ansible_facts.distribution == 'Amazon' and ansible_facts.distribution_major_version | int >= 2023)
       ansible.builtin.include_tasks: fedora/install.yml
 
     - name: Install | Arch
-      when: ansible_distribution == 'Archlinux'
+      when: ansible_facts.distribution == 'Archlinux'
       ansible.builtin.include_tasks: arch/install.yml
 
     - name: Install | OpenSUSE
-      when: ansible_distribution in tailscale_opensuse_family_distros
+      when: ansible_facts.distribution in tailscale_opensuse_family_distros
       ansible.builtin.include_tasks: opensuse/install.yml
 
 - name: Install | Remove legacy state folder

--- a/roles/machine/tasks/main.yml
+++ b/roles/machine/tasks/main.yml
@@ -78,21 +78,21 @@
         name: lsb-release
         cache_valid_time: 3600
         state: present
-      when: ansible_distribution in tailscale_debian_family_distros or ansible_distribution == 'ArchLinux'
+      when: ansible_facts.distribution in tailscale_debian_family_distros or ansible_facts.distribution == 'ArchLinux'
 
     - name: Install lsb_release
       become: true
       ansible.builtin.package:
         name: redhat-lsb-core
         state: present
-      when: ansible_distribution in tailscale_centos_family_distros or ansible_distribution == 'Fedora'
+      when: ansible_facts.distribution in tailscale_centos_family_distros or ansible_facts.distribution == 'Fedora'
 
     - name: Refresh Setup
       ansible.builtin.setup:
 
 - name: Operating System
   ansible.builtin.debug:
-    msg: "{{ ansible_distribution }} {{ ansible_distribution_major_version }} ({{ ansible_distribution_release }})"
+    msg: "{{ ansible_facts.distribution }} {{ ansible_facts.distribution_major_version }} ({{ ansible_facts.distribution_release }})"
 
 - name: Install Tailscale
   when: state == "present" or state == "latest"

--- a/roles/machine/tasks/opensuse/install.yml
+++ b/roles/machine/tasks/opensuse/install.yml
@@ -1,6 +1,6 @@
 ---
 - name: OpenSUSE | Install Tumbleweed
-  when: ansible_distribution == "openSUSE Tumbleweed"
+  when: ansible_facts.distribution == "openSUSE Tumbleweed"
   block:
     - name: OpenSUSE | Install Tumbleweed Repo Key
       become: true
@@ -15,7 +15,7 @@
         state: present
 
 - name: OpenSUSE | Install Leap
-  when: ansible_distribution == "openSUSE Leap"
+  when: ansible_facts.distribution == "openSUSE Leap"
   block:
     - name: OpenSUSE | Install Leap Repo Key
       become: true

--- a/roles/machine/tasks/opensuse/uninstall.yml
+++ b/roles/machine/tasks/opensuse/uninstall.yml
@@ -8,7 +8,7 @@
     key: "{{ tailscale_opensuse_key }}"
 
 - name: OpenSUSE | Remove Tumbleweed
-  when: ansible_distribution == "openSUSE Tumbleweed"
+  when: ansible_facts.distribution == "openSUSE Tumbleweed"
   block:
     - name: OpenSUSE | Remove Tumbleweed Repo Key
       become: true
@@ -23,7 +23,7 @@
         state: absent
 
 - name: OpenSUSE | Remove Leap
-  when: ansible_distribution == "openSUSE Leap"
+  when: ansible_facts.distribution == "openSUSE Leap"
   block:
     - name: OpenSUSE | Remove Leap Repo Key
       become: true

--- a/roles/machine/tasks/uninstall.yml
+++ b/roles/machine/tasks/uninstall.yml
@@ -37,25 +37,25 @@
   when: "not tailscale_manage_binaries_skip"
   block:
     - name: Uninstall | CentOS and related families
-      when: ansible_distribution in tailscale_centos_family_distros
+      when: ansible_facts.distribution in tailscale_centos_family_distros
       ansible.builtin.include_tasks: centos/uninstall.yml
 
     - name: Uninstall | Debian and related families
-      when: ansible_distribution in tailscale_debian_family_distros
+      when: ansible_facts.distribution in tailscale_debian_family_distros
       ansible.builtin.include_tasks: debian/uninstall.yml
 
     - name: Uninstall | Fedora and related families
       when: >
-        ansible_distribution == 'Fedora'
-        or (ansible_distribution == 'Amazon' and ansible_distribution_major_version | int >= 2023)
+        ansible_facts.distribution == 'Fedora'
+        or (ansible_facts.distribution == 'Amazon' and ansible_facts.distribution_major_version | int >= 2023)
       ansible.builtin.include_tasks: fedora/uninstall.yml
 
     - name: Uninstall | Arch
-      when: ansible_distribution == 'Archlinux'
+      when: ansible_facts.distribution == 'Archlinux'
       ansible.builtin.include_tasks: arch/uninstall.yml
 
     - name: Uninstall | OpenSUSE
-      when: ansible_distribution in tailscale_opensuse_family_distros
+      when: ansible_facts.distribution in tailscale_opensuse_family_distros
       ansible.builtin.include_tasks: opensuse/uninstall.yml
 
     - name: Uninstall | Remove Tailscale Daemon State and Logs

--- a/roles/machine/vars/main.yml
+++ b/roles/machine/vars/main.yml
@@ -38,20 +38,20 @@ tailscale_debian_distro:
 
 tailscale_apt_keyring_path: /usr/share/keyrings/tailscale-archive-keyring.gpg
 
-tailscale_apt_deb: deb [signed-by={{ tailscale_apt_keyring_path }}] https://pkgs.tailscale.com/{{ release_stability | lower }}/{{ tailscale_debian_distro[ansible_distribution | lower] }} {{ apt_codename | lower }} main
+tailscale_apt_deb: deb [signed-by={{ tailscale_apt_keyring_path }}] https://pkgs.tailscale.com/{{ release_stability | lower }}/{{ tailscale_debian_distro[ansible_facts.distribution | lower] }} {{ apt_codename | lower }} main
 
-tailscale_apt_signkey: https://pkgs.tailscale.com/{{ release_stability | lower }}/{{ tailscale_debian_distro[ansible_distribution | lower] }}/{{ apt_codename | lower }}.noarmor.gpg
+tailscale_apt_signkey: https://pkgs.tailscale.com/{{ release_stability | lower }}/{{ tailscale_debian_distro[ansible_facts.distribution | lower] }}/{{ apt_codename | lower }}.noarmor.gpg
 
 tailscale_yum_dependencies:
   - yum-utils
   - gnupg
 
 tailscale_yum_repos:
-  CentOS: https://pkgs.tailscale.com/{{ release_stability | lower }}/centos/{{ ansible_distribution_major_version }}/tailscale.repo
-  RedHat: https://pkgs.tailscale.com/{{ release_stability | lower }}/{{ "rhel" if ansible_distribution_major_version | int == 8 else "centos" }}/{{ ansible_distribution_major_version }}/tailscale.repo
-  OracleLinux: https://pkgs.tailscale.com/{{ release_stability | lower }}/centos/{{ ansible_distribution_major_version }}/tailscale.repo
-  Rocky: https://pkgs.tailscale.com/{{ release_stability | lower }}/centos/{{ ansible_distribution_major_version }}/tailscale.repo
-  AlmaLinux: https://pkgs.tailscale.com/{{ release_stability | lower }}/centos/{{ ansible_distribution_major_version }}/tailscale.repo
+  CentOS: https://pkgs.tailscale.com/{{ release_stability | lower }}/centos/{{ ansible_facts.distribution_major_version }}/tailscale.repo
+  RedHat: https://pkgs.tailscale.com/{{ release_stability | lower }}/{{ "rhel" if ansible_facts.distribution_major_version | int == 8 else "centos" }}/{{ ansible_facts.distribution_major_version }}/tailscale.repo
+  OracleLinux: https://pkgs.tailscale.com/{{ release_stability | lower }}/centos/{{ ansible_facts.distribution_major_version }}/tailscale.repo
+  Rocky: https://pkgs.tailscale.com/{{ release_stability | lower }}/centos/{{ ansible_facts.distribution_major_version }}/tailscale.repo
+  AlmaLinux: https://pkgs.tailscale.com/{{ release_stability | lower }}/centos/{{ ansible_facts.distribution_major_version }}/tailscale.repo
 
 tailscale_dnf_dependencies:
   - python-dnf
@@ -63,9 +63,9 @@ tailscale_dnf_repos:
   Amazon: https://pkgs.tailscale.com/{{ release_stability | lower }}/fedora/tailscale.repo
   Fedora: https://pkgs.tailscale.com/{{ release_stability | lower }}/fedora/tailscale.repo
 
-tailscale_opensuse_leap_key: https://pkgs.tailscale.com/{{ release_stability | lower }}/opensuse/leap/{{ ansible_distribution_version }}/repo.gpg
-tailscale_opensuse_leap_repository: https://pkgs.tailscale.com/stable/opensuse/leap/{{ ansible_distribution_version }}/tailscale.repo
+tailscale_opensuse_leap_key: https://pkgs.tailscale.com/{{ release_stability | lower }}/opensuse/leap/{{ ansible_facts.distribution_version }}/repo.gpg
+tailscale_opensuse_leap_repository: https://pkgs.tailscale.com/stable/opensuse/leap/{{ ansible_facts.distribution_version }}/tailscale.repo
 tailscale_opensuse_tumbleweed_key: https://pkgs.tailscale.com/{{ release_stability | lower }}/opensuse/tumbleweed/repo.gpg
 tailscale_opensuse_tumbleweed_repository: https://pkgs.tailscale.com/{{ release_stability | lower }}/opensuse/tumbleweed/tailscale.repo
 
-tailscale_original_distribution_major_version: "{{ ansible_distribution_major_version }}"
+tailscale_original_distribution_major_version: "{{ ansible_facts.distribution_major_version }}"


### PR DESCRIPTION
Fix for:

```sh
[DEPRECATION WARNING]: INJECT_FACTS_AS_VARS default to `True` is deprecated, top-level facts will not be auto injected after the change. This feature will be removed from ansible-core version 2.24.
```